### PR TITLE
Move Optional Requirements to extras_require

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-aiodns
 aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-cchardet
 aiodns
 aiohttp

--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,7 @@ setup(name='achallonge',
         'Topic :: Utilities',
       ],
       keywords=['challonge',  'tournament', 'match'],
+      extras_require = {
+        'speed':  ['cchardet', 'aiodns']
+    }
       )


### PR DESCRIPTION
To avoid package bloat and Build Tools hassle.
```python
pip install achallonge[speed]
```