### PR TITLE
Replace dependency of cchardet with faust-cchardet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Modern library that is more than just a wrapper for the Challonge web API
 * `aiohttp`
 
 Optional:
- * `cchardet` faster replacement for chardet, as mentionned on the aiohttp page
+ * `faust-cchardet` faster replacement for chardet, as mentionned on the aiohttp page
  * `aiodns` for speeding up DNS resolving, highly recommended by aiohttp
 
 # Python version support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Dependencies
 
 - python 3.5+
 - aiohttp
-    - cchardet
+    - faust-cchardet
     - aiodns
 
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 aiohttp==3.6.0
-cchardet
+faust-cchardet
 aiodns
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='achallonge',
       packages=find_packages(),
       install_requires=requirements,
       extras_require={
-        'speed':  ['cchardet', 'aiodns']
+        'speed':  ['faust-cchardet', 'aiodns']
       },
 
       include_package_data=True,


### PR DESCRIPTION
As seen [here](https://github.com/PythonistaGuild/TwitchIO/issues/393), `cchardet` is no longer being developed.
Currently, `pip install achallonge[speed]` has issues compiling in python 3.12 because of it.

Thus, switch `CChardet` to `faust-cchardet`
